### PR TITLE
chore: bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livelyvideomobile/react-native-webrtc",
-  "version": "1.95.0",
+  "version": "1.95.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/LivelyVideo/react-native-webrtc.git"


### PR DESCRIPTION
Previous commit was to fix the podspec name.  Forgot to rev bump it and rev bump video-client
https://github.com/LivelyVideo/react-native-webrtc/commit/0b6a235ad9872f00dfaeb18e0f257cabf2943d4b